### PR TITLE
Make generated tests pass

### DIFF
--- a/lib/Mojolicious/Command/Author/generate/localplugin.pm
+++ b/lib/Mojolicious/Command/Author/generate/localplugin.pm
@@ -24,7 +24,7 @@ sub run {
 
   # Test
   my $testname    = decamelize $class;
-  my @test_params = ({ name => $name });
+  my @test_params = ({ class => $class, name => $name });
   $self->render_to_rel_file('test', "t/$testname.t", @test_params);
 }
 
@@ -144,7 +144,7 @@ use Test::More;
 use Mojolicious::Lite;
 use Test::Mojo;
 
-plugin '<%= $name %>';
+plugin '<%= $class %>';
 
 get '/' => sub {
   my $c = shift;

--- a/t/base.t
+++ b/t/base.t
@@ -35,6 +35,18 @@ ok -e $plugin->rel_file(
   'class exists';
 ok -e $plugin->rel_file('t/my_plugin.t'), 'test exists';
 
+{
+  note "Subtest: Run tests for MyPlugin";
+
+  open my $fh, '-|', $^X => -I, $plugin->rel_file('lib'),
+    $plugin->rel_file('t/my_plugin.t')
+    or fail "Failed to open test: $!";
+  print "    $_" while readline $fh;
+  close $fh or fail "Failed to close test handle: $!";
+
+  is $?, 0, "Ran tests for MyPlugin";
+}
+
 chdir $cwd;
 
 done_testing();

--- a/t/run.t
+++ b/t/run.t
@@ -35,7 +35,7 @@ ok -e $plugin->rel_file(
   'class exists';
 ok -e $plugin->rel_file('t/test_plugin.t'), 'test exists';
 
-TODO: { local $TODO = "Should find the Plugin, but doesn't";
+{
   note "Subtest: Run tests for test_plugin";
 
   open my $fh, '-|', $^X => -I, $plugin->rel_file('lib/'),

--- a/t/run.t
+++ b/t/run.t
@@ -35,6 +35,18 @@ ok -e $plugin->rel_file(
   'class exists';
 ok -e $plugin->rel_file('t/test_plugin.t'), 'test exists';
 
+TODO: { local $TODO = "Should find the Plugin, but doesn't";
+  note "Subtest: Run tests for test_plugin";
+
+  open my $fh, '-|', $^X => -I, $plugin->rel_file('lib/'),
+    $plugin->rel_file('t/test_plugin.t')
+    or fail "Failed to open test: $!";
+  print "    $_" while readline $fh;
+  close $fh or fail "Failed to close test handle: $!";
+
+  is $?, 0, "Ran tests for test_plugin";
+}
+
 chdir $cwd;
 
 done_testing();


### PR DESCRIPTION
I got this repo from the pullrequest.club but without any Issues I wasn't sure what to work on.  Of course, I had no real idea what the project did and so I tried it out and realized that the generated code didn't pass its generated tests.  After much digging, I figured out that [Mojolicious::Plugins  won't find the TestPlugin if you try to load it as "test_plugin"](https://metacpan.org/release/Mojolicious/source/lib/Mojolicious/Plugins.pm#L38).  It always looks for the camelized version in a namespace, and then the exact name.  It never tries to load the camelized version by itself.  

This PR adjusts the tests to be generated to load the Plugin by class name instead of short name and runs the generated tests as part of the test suite.